### PR TITLE
mvn tomcat:run may fail, option to use mvn tomcat7:run

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,16 @@ Maven plugins configuration:
 
 add this to .m2/settings.xml
 
-  <pluginGroups>
-    <!-- pluginGroup
-     | Specifies a further group identifier to use for plugin lookup.
-    <pluginGroup>com.your.plugins</pluginGroup>
-    -->
-	 <!-- http://tomcat.apache.org/maven-plugin-2.0/ -->
-	 <pluginGroup>org.apache.tomcat.maven</pluginGroup>
-     <!-- http://docs.codehaus.org/display/JETTY/Maven+Jetty+Plugin -->
-     <pluginGroup>org.mortbay.jetty</pluginGroup>
-  </pluginGroups>
+    <pluginGroups>
+	     <!-- pluginGroup
+	     | Specifies a further group identifier to use for plugin lookup.
+	    <pluginGroup>com.your.plugins</pluginGroup>
+	    -->
+		 <!-- http://tomcat.apache.org/maven-plugin-2.0/ -->
+		 <pluginGroup>org.apache.tomcat.maven</pluginGroup>
+	     <!-- http://docs.codehaus.org/display/JETTY/Maven+Jetty+Plugin -->
+	     <pluginGroup>org.mortbay.jetty</pluginGroup>
+    </pluginGroups>
 
 run tomcat or Jetty via maven
   


### PR DESCRIPTION
I run into error when trying to run spring-mvc-showcase using maven from command line.
I could not get maven artifacts. It was solved by using The Apache Tomcat Maven Plugin 2 (http://tomcat.apache.org/maven-plugin-2.0/) with mvn tomcat7:run. After that mvn tomcat:run was also OK.
