### PR TITLE
use "tomcat7-maven-plugin" instead of "tomcat-maven-plugin"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run the application:
 From the command line with Maven:
 
     $ cd spring-mvc-showcase
-    $ mvn tomcat:run
+    $ mvn tomcat7:run
 
 or
 

--- a/pom.xml
+++ b/pom.xml
@@ -274,9 +274,9 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>tomcat-maven-plugin</artifactId>
-				<version>1.1</version>
+				<groupId>org.apache.tomcat.maven</groupId>
+				<artifactId>tomcat7-maven-plugin</artifactId>
+				<version>2.0</version>
 			</plugin>	
 		</plugins>
 	</build>


### PR DESCRIPTION
in tomcat6, Matrix variable will fail, such as "/data/matrixvars;foo=bar/simple" will resolve to controller "/simple"
in tomcat6, Async Requests Tab will fail, throw a "java.lang.UnsupportedOperationException: No async support in a pre-Servlet 3.0 runtime"

Changes to get issue #15 working for me.
