### PR TITLE
Fixed errors in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,7 @@
 	</repositories>
 	<build>
 		<finalName>${project.artifactId}</finalName>
+		<pluginManagement>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -297,5 +298,6 @@
 				</configuration>
 			</plugin>
 		</plugins>
+		</pluginManagement>
 	</build>
 </project>


### PR DESCRIPTION
Maven version : 3.2.1
Error details :
- Plugin execution not covered by lifecycle configuration:
  org.codehaus.mojo:aspectj-maven-plugin:   1.2:test-compile 
  (execution: default, phase: process-test-sources)
- Plugin execution not covered by lifecycle configuration: org.codehaus.mojo:aspectj-maven-plugin:   1.2:compile (execution: default, phase: process-sources)
