### PR TITLE
Add bean name to property accessors in html.jsp

### DIFF
--- a/src/main/webapp/WEB-INF/views/views/html.jsp
+++ b/src/main/webapp/WEB-INF/views/views/html.jsp
@@ -3,12 +3,12 @@
 <html>
 <head>
 	<title>My HTML View</title>
-	<link href="<c:url value="/resources/form.css" />" rel="stylesheet"  type="text/css" />		
+	<link href="<c:url value="/resources/form.css" />" rel="stylesheet"  type="text/css" />
 </head>
 <body>
 <div class="success">
-	<h3>foo: "${foo}"</h3>
-	<h3>fruit: "${fruit}"</h3>
+	<h3>foo: "${javaBean.foo}"</h3>
+	<h3>fruit: "${javaBean.fruit}"</h3>
 </div>
 </body>
 </html>


### PR DESCRIPTION
html.jsp missing bean name "javaBean" in property accessors. Add name to
accessors, e.g. ${javaBean.fruit} so model data will appear in the view.
