### PR TITLE
Maven 3 & dcover default test name compatibility [TG-11622]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,12 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>LATEST</version>
+			<version>2.13.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>LATEST</version>
+			<version>2.13.3</version>
 		</dependency>
 
 		<!-- @Inject -->

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,7 @@
 				<version>2.20.1</version>
 				<configuration>
 					<includes>
+						<include>**/*Test.java</include>
 						<include>**/*Tests.java</include>
 					</includes>
 					<excludes>


### PR DESCRIPTION
The LATEST syntax for dependency versions is not supported in Maven 3, so change these to explicit version numbers

dcover by default generates classes with names ending in Test, whereas the project was configured only to look for tests ending in Tests. Reconfigure the project to look for tests ending in both Test and Tests.

### QA Notes

#### Automated tests

I don't think there are meaningful unit tests that can be written for this PR

#### Manual tests

On master, running `mvn install` or similar when using Maven 3, the project will fail to build due to dependencies being unmet. If this is manually corrected, then after running `dcover create` then running `mvn test`, the tests newly created Diffblue Cover will not be run.

On this branch, running `mvn install` or similar when using Maven 3 will end in a successful build. When running `mvn test` after `dcover create`, the tests newly created by Diffblue Cover will be run (and pass!).